### PR TITLE
[FIX] don't checkout build repo

### DIFF
--- a/travis/clone_oca_dependencies
+++ b/travis/clone_oca_dependencies
@@ -70,6 +70,11 @@ def git_checkout(deps_checkout_dir, reponame, url, branch):
 def run(deps_checkout_dir, build_dir):
     dependencies = []
     processed = set()
+
+    # don't checkout build repo:
+    build_name = build_dir.split('/')[-1]
+    processed.add(build_name)
+
     depfilename = osp.join(build_dir, 'oca_dependencies.txt')
     dependencies.append(depfilename)
     reqfilenames = []


### PR DESCRIPTION
Example: if build repo is website-addons, which depends on misc-addons,
which depends on website-addons, then without this update there will be
updated repo and non-update version of repo